### PR TITLE
Upgrade to OnTopic 3.8.0

### DIFF
--- a/ApplicationInsights.config
+++ b/ApplicationInsights.config
@@ -8,6 +8,12 @@
 
     Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
   -->
+  <!--
+    Learn more about Application Insights configuration with ApplicationInsights.config here:
+    http://go.microsoft.com/fwlink/?LinkID=513840
+
+    Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
+  -->
   <TelemetryInitializers>
     <Add Type="Microsoft.ApplicationInsights.DependencyCollector.HttpDependenciesParsingTelemetryInitializer, Microsoft.AI.DependencyCollector"/>
     <Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureRoleEnvironmentTelemetryInitializer, Microsoft.AI.WindowsServer"/>
@@ -30,8 +36,8 @@
   <TelemetryModules>
     <Add Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector">
       <ExcludeComponentCorrelationHttpHeadersOnDomains>
-        <!--
-        Requests to the following hostnames will not be modified by adding correlation headers.
+        <!-- 
+        Requests to the following hostnames will not be modified by adding correlation headers.         
         Add entries here to exclude additional hostnames.
         NOTE: this configuration will be lost upon NuGet upgrade.
         -->
@@ -39,8 +45,6 @@
         <Add>core.chinacloudapi.cn</Add>
         <Add>core.cloudapi.de</Add>
         <Add>core.usgovcloudapi.net</Add>
-        <Add>localhost</Add>
-        <Add>127.0.0.1</Add>
       </ExcludeComponentCorrelationHttpHeadersOnDomains>
       <IncludeDiagnosticSourceActivities>
         <Add>Microsoft.Azure.EventHubs</Add>
@@ -50,16 +54,16 @@
     <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.PerformanceCollectorModule, Microsoft.AI.PerfCounterCollector">
       <!--
       Use the following syntax here to collect additional performance counters:
-
+      
       <Counters>
         <Add PerformanceCounter="\Process(??APP_WIN32_PROC??)\Handle Count" ReportAs="Process handle count" />
         ...
       </Counters>
-
+      
       PerformanceCounter must be either \CategoryName(InstanceName)\CounterName or \CategoryName\CounterName
-
+      
       NOTE: performance counters configuration will be lost upon NuGet upgrade.
-
+      
       The following placeholders are supported as InstanceName:
         ??APP_WIN32_PROC?? - instance name of the application process  for Win32 counters.
         ??APP_W3SVC_PROC?? - instance name of the application IIS worker process for IIS/ASP.NET counters.
@@ -70,9 +74,9 @@
     <Add Type="Microsoft.ApplicationInsights.WindowsServer.AppServicesHeartbeatTelemetryModule, Microsoft.AI.WindowsServer"/>
     <Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureInstanceMetadataTelemetryModule, Microsoft.AI.WindowsServer">
       <!--
-      Remove individual fields collected here by adding them to the ApplicationInsighs.HeartbeatProvider
+      Remove individual fields collected here by adding them to the ApplicationInsighs.HeartbeatProvider 
       with the following syntax:
-
+      
       <Add Type="Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule, Microsoft.ApplicationInsights">
         <ExcludedHeartbeatProperties>
           <Add>osType</Add>
@@ -88,9 +92,12 @@
           <Add>vmSize</Add>
           <Add>subscriptionId</Add>
           <Add>resourceGroupName</Add>
+          <Add>placementGroupId</Add>
+          <Add>tags</Add>
+          <Add>vmScaleSetName</Add>
         </ExcludedHeartbeatProperties>
       </Add>
-
+            
       NOTE: exclusions will be lost upon upgrade.
       -->
     </Add>
@@ -102,9 +109,9 @@
     </Add>
     <Add Type="Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModule, Microsoft.AI.Web">
       <Handlers>
-        <!--
-        Add entries here to filter out additional handlers:
-
+        <!-- 
+        Add entries here to filter out additional handlers: 
+        
         NOTE: handler configuration will be lost upon NuGet upgrade.
         -->
         <Add>Microsoft.VisualStudio.Web.PageInspector.Runtime.Tracing.RequestDataHttpHandler</Add>
@@ -120,43 +127,35 @@
     <Add Type="Microsoft.ApplicationInsights.Web.ExceptionTrackingTelemetryModule, Microsoft.AI.Web"/>
     <Add Type="Microsoft.ApplicationInsights.Web.AspNetDiagnosticTelemetryModule, Microsoft.AI.Web"/>
   </TelemetryModules>
-  <ApplicationIdProvider Type="Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId.ApplicationInsightsApplicationIdProvider, Microsoft.ApplicationInsights"/>
-  <TelemetryProcessors>
-    <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector"/>
-    <Add Type="Microsoft.ApplicationInsights.Extensibility.AutocollectedMetricsExtractor, Microsoft.ApplicationInsights"/>
-    <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
-      <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
-      <ExcludedTypes>Event</ExcludedTypes>
+  <TelemetrySinks>
+    <Add Name="default">
+      <TelemetryProcessors>
+        <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector"/>
+        <Add Type="Microsoft.ApplicationInsights.Extensibility.AutocollectedMetricsExtractor, Microsoft.ApplicationInsights"/>
+        <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+          <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+          <ExcludedTypes>Event</ExcludedTypes>
+        </Add>
+        <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+          <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+          <IncludedTypes>Event</IncludedTypes>
+        </Add>
+      </TelemetryProcessors>
+      <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>
     </Add>
-    <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
-      <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
-      <IncludedTypes>Event</IncludedTypes>
-    </Add>
-    <Add Type="Microsoft.ApplicationInsights.SnapshotCollector.SnapshotCollectorTelemetryProcessor, Microsoft.ApplicationInsights.SnapshotCollector">
-      <!-- The default is true, but you can disable Snapshot Debugging by setting it to false -->
-      <IsEnabled>true</IsEnabled>
-      <!-- Snapshot Debugging is usually disabled in developer mode, but you can enable it by setting this to true. -->
-      <!-- DeveloperMode is a property on the active TelemetryChannel. -->
-      <IsEnabledInDeveloperMode>false</IsEnabledInDeveloperMode>
-      <!-- How many times we need to see an exception before we ask for snapshots. -->
-      <ThresholdForSnapshotting>1</ThresholdForSnapshotting>
-      <!-- The maximum number of snapshots we collect for a single problem. -->
-      <MaximumSnapshotsRequired>3</MaximumSnapshotsRequired>
-      <!-- The maximum number of problems that we can be tracking at any time. -->
-      <MaximumCollectionPlanSize>50</MaximumCollectionPlanSize>
-      <!-- How often to reset problem counters. -->
-      <ProblemCounterResetInterval>24:00:00</ProblemCounterResetInterval>
-      <!-- The maximum number of snapshots allowed per day. -->
-      <SnapshotsPerDayLimit>30</SnapshotsPerDayLimit>
-      <!--Whether or not to collect snapshot in low IO priority thread.-->
-      <SnapshotInLowPriorityThread>true</SnapshotInLowPriorityThread>
-    </Add>
-  </TelemetryProcessors>
-  <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>
-  <!--
-    Learn more about Application Insights configuration with ApplicationInsights.config here:
+  </TelemetrySinks>
+<!-- 
+    Learn more about Application Insights configuration with ApplicationInsights.config here: 
     http://go.microsoft.com/fwlink/?LinkID=513840
-
+    
     Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
   -->
+<ApplicationIdProvider Type="Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId.ApplicationInsightsApplicationIdProvider, Microsoft.ApplicationInsights"/>
+<TelemetryProcessors>
+<Add Type="Microsoft.ApplicationInsights.SnapshotCollector.SnapshotCollectorTelemetryProcessor, Microsoft.ApplicationInsights.SnapshotCollector">
+<!-- Snapshot Debugging is usually disabled when debugging in Visual Studio, but you can enable it by setting this to true. -->
+<IsEnabledInDeveloperMode>false</IsEnabledInDeveloperMode>
+<!-- Other properties are documented at https://aka.ms/pnv0qt -->
+</Add>
+</TelemetryProcessors>
 </ApplicationInsights>

--- a/Controllers/LayoutController.cs
+++ b/Controllers/LayoutController.cs
@@ -20,7 +20,12 @@ namespace GoldSim.Web.Controllers {
   /// <summary>
   ///   Provides access to the default homepage for the site.
   /// </summary>
-  public class LayoutController : CachedLayoutControllerBase<NavigationTopicViewModel> {
+  public class LayoutController : LayoutControllerBase<NavigationTopicViewModel> {
+
+    /*==========================================================================================================================
+    | PRIVATE FIELDS
+    \-------------------------------------------------------------------------------------------------------------------------*/
+    private readonly            ITopicRepository                _topicRepository                = null;
 
     /*==========================================================================================================================
     | CONSTRUCTOR
@@ -30,14 +35,14 @@ namespace GoldSim.Web.Controllers {
     /// </summary>
     /// <returns>A topic controller for loading OnTopic views.</returns>
     public LayoutController(
-      ITopicRepository topicRepository,
       ITopicRoutingService topicRoutingService,
-      ITopicMappingService topicMappingService
+      IHierarchicalTopicMappingService<NavigationTopicViewModel> hierarchicalTopicMappingService,
+      ITopicRepository topicRepository
     ) : base(
-      topicRepository,
       topicRoutingService,
-      topicMappingService
+      hierarchicalTopicMappingService
     ) {
+      _topicRepository = topicRepository;
     }
 
     /*==========================================================================================================================
@@ -72,7 +77,7 @@ namespace GoldSim.Web.Controllers {
       | Construct view model
       \-----------------------------------------------------------------------------------------------------------------------*/
       var navigationViewModel = new NavigationViewModel<NavigationTopicViewModel>() {
-        NavigationRoot = await GetRootViewModelAsync(navigationRootTopic),
+        NavigationRoot = await HierarchicalTopicMappingService.GetRootViewModelAsync(navigationRootTopic),
         CurrentKey = CurrentTopic?.GetUniqueKey()
       };
 
@@ -101,13 +106,13 @@ namespace GoldSim.Web.Controllers {
       >-------------------------------------------------------------------------------------------------------------------------
       | The navigation root in the case of the main menu is the namespace; i.e., the first topic underneath the root.
       \-----------------------------------------------------------------------------------------------------------------------*/
-      var navigationRootTopic = base.GetNavigationRoot(currentTopic, 3, "Web");
+      var navigationRootTopic = HierarchicalTopicMappingService.GetHierarchicalRoot(currentTopic, 3, "Web");
 
       /*------------------------------------------------------------------------------------------------------------------------
       | Construct view model
       \-----------------------------------------------------------------------------------------------------------------------*/
       var navigationViewModel = new NavigationViewModel<NavigationTopicViewModel>() {
-        NavigationRoot = await GetRootViewModelAsync(navigationRootTopic),
+        NavigationRoot = await HierarchicalTopicMappingService.GetRootViewModelAsync(navigationRootTopic),
         CurrentKey = CurrentTopic?.GetUniqueKey()
       };
 
@@ -129,14 +134,14 @@ namespace GoldSim.Web.Controllers {
       /*------------------------------------------------------------------------------------------------------------------------
       | Establish variables
       \-----------------------------------------------------------------------------------------------------------------------*/
-      var navigationRootTopic = TopicRepository.Load("Web:Company");
+      var navigationRootTopic = _topicRepository.Load("Web:Company");
       var currentTopic = CurrentTopic;
 
       /*------------------------------------------------------------------------------------------------------------------------
       | Construct view model
       \-----------------------------------------------------------------------------------------------------------------------*/
       var navigationViewModel = new NavigationViewModel<NavigationTopicViewModel>() {
-        NavigationRoot = await GetRootViewModelAsync(navigationRootTopic),
+        NavigationRoot = await HierarchicalTopicMappingService.GetRootViewModelAsync(navigationRootTopic),
         CurrentKey = CurrentTopic?.GetUniqueKey()
       };
 

--- a/Controllers/PaymentsController.cs
+++ b/Controllers/PaymentsController.cs
@@ -18,6 +18,7 @@ using Ignia.Topics.Mapping;
 using Ignia.Topics.Repositories;
 using Ignia.Topics.Web.Mvc;
 using Ignia.Topics.Web.Mvc.Controllers;
+using Decimal = System.Decimal;
 
 namespace GoldSim.Web.Controllers {
 

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -18,7 +18,7 @@
     <AssemblyName>GoldSim.Web</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
-    <IISExpressSSLPort>63082</IISExpressSSLPort>
+    <IISExpressSSLPort>44300</IISExpressSSLPort>
     <IISExpressAnonymousAuthentication>enabled</IISExpressAnonymousAuthentication>
     <IISExpressWindowsAuthentication>disabled</IISExpressWindowsAuthentication>
     <IISExpressUseClassicPipelineMode>false</IISExpressUseClassicPipelineMode>
@@ -94,22 +94,22 @@
       <HintPath>..\..\Topics\201707\Ignia.Toolbox.dll</HintPath>
     </Reference>
     <Reference Include="Ignia.Topics, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.3.8.0-alpha.257\lib\net47\Ignia.Topics.dll</HintPath>
+      <HintPath>packages\Ignia.Topics.3.8.0-alpha.267\lib\net48\Ignia.Topics.dll</HintPath>
     </Reference>
     <Reference Include="Ignia.Topics.Data.Caching, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Data.Caching.3.8.0-alpha.257\lib\net47\Ignia.Topics.Data.Caching.dll</HintPath>
+      <HintPath>packages\Ignia.Topics.Data.Caching.3.8.0-alpha.267\lib\net48\Ignia.Topics.Data.Caching.dll</HintPath>
     </Reference>
     <Reference Include="Ignia.Topics.Data.Sql, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Data.Sql.3.8.0-alpha.257\lib\net47\Ignia.Topics.Data.Sql.dll</HintPath>
+      <HintPath>packages\Ignia.Topics.Data.Sql.3.8.0-alpha.267\lib\net48\Ignia.Topics.Data.Sql.dll</HintPath>
     </Reference>
     <Reference Include="Ignia.Topics.ViewModels, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.ViewModels.3.8.0-alpha.257\lib\net47\Ignia.Topics.ViewModels.dll</HintPath>
+      <HintPath>packages\Ignia.Topics.ViewModels.3.8.0-alpha.267\lib\net48\Ignia.Topics.ViewModels.dll</HintPath>
     </Reference>
     <Reference Include="Ignia.Topics.Web, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Web.3.8.0-alpha.257\lib\net47\Ignia.Topics.Web.dll</HintPath>
+      <HintPath>packages\Ignia.Topics.Web.3.8.0-alpha.267\lib\net48\Ignia.Topics.Web.dll</HintPath>
     </Reference>
     <Reference Include="Ignia.Topics.Web.Mvc, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Web.Mvc.3.8.0-alpha.257\lib\net47\Ignia.Topics.Web.Mvc.dll</HintPath>
+      <HintPath>packages\Ignia.Topics.Web.Mvc.3.8.0-alpha.267\lib\net48\Ignia.Topics.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props" Condition="Exists('packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props')" />
-  <Import Project="packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -141,10 +141,8 @@
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.AspNet.TelemetryCorrelation.1.0.3\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -2515,7 +2513,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
     <Error Condition="!Exists('packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
   </Target>
 </Project>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -218,33 +218,22 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.6\lib\net45\System.Web.Helpers.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.Mvc.5.2.4\lib\net45\System.Web.Mvc.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Web.Mvc, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.Mvc.5.2.7\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.AspNet.Razor.3.2.6\lib\net45\System.Web.Razor.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.6\lib\net45\System.Web.WebPages.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.6\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.6\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\Microsoft.Net.Compilers.3.2.1\build\Microsoft.Net.Compilers.props" Condition="Exists('packages\Microsoft.Net.Compilers.3.2.1\build\Microsoft.Net.Compilers.props')" />
   <Import Project="packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
-  <Import Project="packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props" Condition="Exists('packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -187,6 +187,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Security" />
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
@@ -208,6 +209,7 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -2504,13 +2506,13 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props'))" />
     <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
     <Error Condition="!Exists('packages\Microsoft.ApplicationInsights.DependencyCollector.2.10.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.ApplicationInsights.DependencyCollector.2.10.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.10.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.10.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.ApplicationInsights.WindowsServer.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.ApplicationInsights.WindowsServer.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.ApplicationInsights.Web.2.10.0\build\Microsoft.ApplicationInsights.Web.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.ApplicationInsights.Web.2.10.0\build\Microsoft.ApplicationInsights.Web.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Net.Compilers.3.2.1\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Net.Compilers.3.2.1\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <Import Project="packages\Microsoft.ApplicationInsights.DependencyCollector.2.10.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets" Condition="Exists('packages\Microsoft.ApplicationInsights.DependencyCollector.2.10.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets')" />
   <Import Project="packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.10.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets" Condition="Exists('packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.10.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets')" />

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -181,8 +181,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+    <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -16,7 +16,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GoldSim.Web</RootNamespace>
     <AssemblyName>GoldSim.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort>63082</IISExpressSSLPort>
     <IISExpressAnonymousAuthentication>enabled</IISExpressAnonymousAuthentication>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -93,23 +93,23 @@
     <Reference Include="Ignia.Toolbox">
       <HintPath>..\..\Topics\201707\Ignia.Toolbox.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.dll</HintPath>
+    <Reference Include="Ignia.Topics, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.3.8.0-alpha.257\lib\net47\Ignia.Topics.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics.Data.Caching, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.Data.Caching.dll</HintPath>
+    <Reference Include="Ignia.Topics.Data.Caching, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.Data.Caching.3.8.0-alpha.257\lib\net47\Ignia.Topics.Data.Caching.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics.Data.Sql, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Data.Sql.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.Data.Sql.dll</HintPath>
+    <Reference Include="Ignia.Topics.Data.Sql, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.Data.Sql.3.8.0-alpha.257\lib\net47\Ignia.Topics.Data.Sql.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics.ViewModels, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.ViewModels.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.ViewModels.dll</HintPath>
+    <Reference Include="Ignia.Topics.ViewModels, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.ViewModels.3.8.0-alpha.257\lib\net47\Ignia.Topics.ViewModels.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics.Web, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Web.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.Web.dll</HintPath>
+    <Reference Include="Ignia.Topics.Web, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.Web.3.8.0-alpha.257\lib\net47\Ignia.Topics.Web.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics.Web.Mvc, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Web.Mvc.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.Web.Mvc.dll</HintPath>
+    <Reference Include="Ignia.Topics.Web.Mvc, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.Web.Mvc.3.8.0-alpha.257\lib\net47\Ignia.Topics.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
@@ -156,17 +156,58 @@
       <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.ComponentModel.Annotations.4.5.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Linq" />
+    <Reference Include="System.Data.SqlClient, Version=4.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Data.SqlClient.4.6.0\lib\net461\System.Data.SqlClient.dll</HintPath>
+    </Reference>
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Linq, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Linq.4.3.0\lib\net463\System.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Security" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -163,8 +163,8 @@
     <Reference Include="System.Data.SqlClient, Version=4.5.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Data.SqlClient.4.6.1\lib\net461\System.Data.SqlClient.dll</HintPath>
     </Reference>
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -190,7 +190,7 @@
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Security" />
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <HintPath>packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -204,8 +204,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -82,8 +82,8 @@
     <Reference Include="Braintree, Version=4.14.0.0, Culture=neutral, PublicKeyToken=31b586f34d3e96c7, processorArchitecture=MSIL">
       <HintPath>packages\Braintree.4.14.0\lib\net452\Braintree.dll</HintPath>
     </Reference>
-    <Reference Include="EPPlus, Version=4.5.2.0, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
-      <HintPath>packages\EPPlus.4.5.2\lib\net40\EPPlus.dll</HintPath>
+    <Reference Include="EPPlus, Version=4.5.3.2, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
+      <HintPath>packages\EPPlus.4.5.3.2\lib\net40\EPPlus.dll</HintPath>
     </Reference>
     <Reference Include="HtmlSanitizationLibrary, Version=4.3.0.0, Culture=neutral, PublicKeyToken=d127efab8a9c114f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -135,8 +135,8 @@
     <Reference Include="Microsoft.ApplicationInsights.SnapshotCollector, Version=1.3.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.ApplicationInsights.SnapshotCollector.1.3.5\lib\net45\Microsoft.ApplicationInsights.SnapshotCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights.TraceListener, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.TraceListener.2.6.4\lib\net45\Microsoft.ApplicationInsights.TraceListener.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights.TraceListener, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.ApplicationInsights.TraceListener.2.10.0\lib\net45\Microsoft.ApplicationInsights.TraceListener.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -79,8 +79,8 @@
       <HintPath>packages\AntiXSS.4.3.0\lib\net40\AntiXssLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Braintree, Version=4.7.0.0, Culture=neutral, PublicKeyToken=31b586f34d3e96c7, processorArchitecture=MSIL">
-      <HintPath>packages\Braintree.4.7.0\lib\net452\Braintree.dll</HintPath>
+    <Reference Include="Braintree, Version=4.14.0.0, Culture=neutral, PublicKeyToken=31b586f34d3e96c7, processorArchitecture=MSIL">
+      <HintPath>packages\Braintree.4.14.0\lib\net452\Braintree.dll</HintPath>
     </Reference>
     <Reference Include="EPPlus, Version=4.5.2.0, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
       <HintPath>packages\EPPlus.4.5.2\lib\net40\EPPlus.dll</HintPath>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -160,8 +160,8 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Linq" />
-    <Reference Include="System.Data.SqlClient, Version=4.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Data.SqlClient.4.6.0\lib\net461\System.Data.SqlClient.dll</HintPath>
+    <Reference Include="System.Data.SqlClient, Version=4.5.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Data.SqlClient.4.6.1\lib\net461\System.Data.SqlClient.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -93,23 +93,23 @@
     <Reference Include="Ignia.Toolbox">
       <HintPath>..\..\Topics\201707\Ignia.Toolbox.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics, Version=3.7.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.3.7.1\lib\net47\Ignia.Topics.dll</HintPath>
+    <Reference Include="Ignia.Topics, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics.Data.Caching, Version=3.7.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Data.Caching.3.7.1\lib\net47\Ignia.Topics.Data.Caching.dll</HintPath>
+    <Reference Include="Ignia.Topics.Data.Caching, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.Data.Caching.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics.Data.Sql, Version=3.7.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Data.Sql.3.7.1\lib\net47\Ignia.Topics.Data.Sql.dll</HintPath>
+    <Reference Include="Ignia.Topics.Data.Sql, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.Data.Sql.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.Data.Sql.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics.ViewModels, Version=3.7.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.ViewModels.3.7.1\lib\net47\Ignia.Topics.ViewModels.dll</HintPath>
+    <Reference Include="Ignia.Topics.ViewModels, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.ViewModels.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.ViewModels.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics.Web, Version=3.7.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Web.3.7.1\lib\net47\Ignia.Topics.Web.dll</HintPath>
+    <Reference Include="Ignia.Topics.Web, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.Web.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.Web.dll</HintPath>
     </Reference>
-    <Reference Include="Ignia.Topics.Web.Mvc, Version=3.7.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ignia.Topics.Web.Mvc.3.7.1\lib\net47\Ignia.Topics.Web.Mvc.dll</HintPath>
+    <Reference Include="Ignia.Topics.Web.Mvc, version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ignia.Topics.Web.Mvc.3.8.0-dotnetstandard0001\lib\net47\Ignia.Topics.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -114,32 +114,32 @@
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.DependencyCollector.2.6.4\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
+    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.ApplicationInsights.DependencyCollector.2.10.0\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.6.4\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
+    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.10.0\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.6.4\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.10.0\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.Web, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.Web.2.6.4\lib\net45\Microsoft.AI.Web.dll</HintPath>
+    <Reference Include="Microsoft.AI.Web, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.ApplicationInsights.Web.2.10.0\lib\net45\Microsoft.AI.Web.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.WindowsServer, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.WindowsServer.2.6.4\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
+    <Reference Include="Microsoft.AI.WindowsServer, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.ApplicationInsights.WindowsServer.2.10.0\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.2.6.4\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.ApplicationInsights.2.10.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights.SnapshotCollector, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.SnapshotCollector.1.3.0\lib\net45\Microsoft.ApplicationInsights.SnapshotCollector.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights.SnapshotCollector, Version=1.3.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.ApplicationInsights.SnapshotCollector.1.3.5\lib\net45\Microsoft.ApplicationInsights.SnapshotCollector.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights.TraceListener, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.ApplicationInsights.TraceListener.2.6.4\lib\net45\Microsoft.ApplicationInsights.TraceListener.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.TelemetryCorrelation.1.0.3\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
@@ -174,6 +174,7 @@
     <Reference Include="System.Linq, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Linq.4.3.0\lib\net463\System.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="System.Management" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
@@ -185,6 +186,7 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Security" />
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
@@ -2515,5 +2517,15 @@
     </PropertyGroup>
     <Error Condition="!Exists('packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props'))" />
     <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.ApplicationInsights.DependencyCollector.2.10.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.ApplicationInsights.DependencyCollector.2.10.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.10.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.10.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.ApplicationInsights.WindowsServer.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.ApplicationInsights.WindowsServer.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.ApplicationInsights.Web.2.10.0\build\Microsoft.ApplicationInsights.Web.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.ApplicationInsights.Web.2.10.0\build\Microsoft.ApplicationInsights.Web.targets'))" />
   </Target>
+  <Import Project="packages\Microsoft.ApplicationInsights.DependencyCollector.2.10.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets" Condition="Exists('packages\Microsoft.ApplicationInsights.DependencyCollector.2.10.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets')" />
+  <Import Project="packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.10.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets" Condition="Exists('packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.10.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets')" />
+  <Import Project="packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets" Condition="Exists('packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets')" />
+  <Import Project="packages\Microsoft.ApplicationInsights.WindowsServer.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.targets" Condition="Exists('packages\Microsoft.ApplicationInsights.WindowsServer.2.10.0\build\Microsoft.ApplicationInsights.WindowsServer.targets')" />
+  <Import Project="packages\Microsoft.ApplicationInsights.Web.2.10.0\build\Microsoft.ApplicationInsights.Web.targets" Condition="Exists('packages\Microsoft.ApplicationInsights.Web.2.10.0\build\Microsoft.ApplicationInsights.Web.targets')" />
 </Project>

--- a/GoldSim.Web.csproj
+++ b/GoldSim.Web.csproj
@@ -150,8 +150,8 @@
       <HintPath>packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Models/NavigationTopicViewModel.cs
+++ b/Models/NavigationTopicViewModel.cs
@@ -23,7 +23,7 @@ namespace GoldSim.Web.Models {
   public class NavigationTopicViewModel: PageTopicViewModel, INavigationTopicViewModel<NavigationTopicViewModel> {
 
     public string HeaderImageUrl { get; set; }
-    public virtual Collection<NavigationTopicViewModel> Children { get; set; }
+    public virtual Collection<NavigationTopicViewModel> Children { get; } = new Collection<NavigationTopicViewModel>();
     public bool IsSelected(string uniqueKey) => $"{uniqueKey}:"?.StartsWith($"{UniqueKey}:") ?? false;
 
 

--- a/Models/NavigationTopicViewModel.cs
+++ b/Models/NavigationTopicViewModel.cs
@@ -6,6 +6,7 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Ignia.Topics;
+using Ignia.Topics.Models;
 using Ignia.Topics.ViewModels;
 
 namespace GoldSim.Web.Models {

--- a/Web.config
+++ b/Web.config
@@ -51,7 +51,7 @@
         <add name="Membership" connectionStringName="Membership" enablePasswordRetrieval="true" enablePasswordReset="true" requiresQuestionAndAnswer="false" requiresUniqueEmail="true" passwordFormat="Clear" minRequiredNonalphanumericCharacters="0" passwordStrengthRegularExpression="" minRequiredPasswordLength="1" applicationName="GoldSim" maxInvalidPasswordAttempts="20" type="System.Web.Security.SqlMembershipProvider, System.Web, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </providers>
     </membership>
-    <compilation debug="true" targetFramework="4.7">
+    <compilation debug="true" targetFramework="4.8">
       <assemblies>
         <add assembly="Ignia.Toolbox" />
         <add assembly="Ignia.Topics" />
@@ -236,8 +236,8 @@
   </runtime>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
   <system.diagnostics>

--- a/Web.config
+++ b/Web.config
@@ -199,7 +199,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />

--- a/Web.config
+++ b/Web.config
@@ -211,7 +211,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.1" newVersion="4.0.3.1" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -231,7 +231,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Web.config
+++ b/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
   <configSections>
@@ -80,6 +80,7 @@
       <forms name="MembershipAuthentication" loginUrl="/Account/Login.aspx" protection="All" timeout="129600" path="/" />
     </authentication>
     <httpModules>
+      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" />
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
     </httpModules>
 
@@ -179,7 +180,7 @@
     </rewrite>
     <modules>
       <remove name="TelemetryCorrelationHttpModule" />
-      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler" />
+      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="managedHandler" />
       <remove name="ApplicationInsightsWebTracking" />
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
     </modules>
@@ -214,7 +215,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.4.0" newVersion="2.6.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />

--- a/Web.config
+++ b/Web.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
   <configSections>
@@ -231,7 +231,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.4.0" newVersion="5.2.4.0" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/packages.config
+++ b/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AntiXSS" version="4.3.0" targetFramework="net47" />
-  <package id="Braintree" version="4.7.0" targetFramework="net47" />
+  <package id="Braintree" version="4.14.0" targetFramework="net48" />
   <package id="EPPlus" version="4.5.2" targetFramework="net47" />
   <package id="Ignia.Topics" version="3.8.0-alpha.257" targetFramework="net48" />
   <package id="Ignia.Topics.Data.Caching" version="3.8.0-alpha.257" targetFramework="net48" />

--- a/packages.config
+++ b/packages.config
@@ -34,7 +34,7 @@
   <package id="System.IO" version="4.3.0" targetFramework="net48" />
   <package id="System.Linq" version="4.3.0" targetFramework="net47" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="net48" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net48" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />

--- a/packages.config
+++ b/packages.config
@@ -3,12 +3,12 @@
   <package id="AntiXSS" version="4.3.0" targetFramework="net47" />
   <package id="Braintree" version="4.7.0" targetFramework="net47" />
   <package id="EPPlus" version="4.5.2" targetFramework="net47" />
-  <package id="Ignia.Topics" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
-  <package id="Ignia.Topics.Data.Sql" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
-  <package id="Ignia.Topics.Data.Caching" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
-  <package id="Ignia.Topics.ViewModels" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
-  <package id="Ignia.Topics.Web" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
-  <package id="Ignia.Topics.Web.Mvc" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics" version="3.8.0-alpha.257" targetFramework="net48" />
+  <package id="Ignia.Topics.Data.Caching" version="3.8.0-alpha.257" targetFramework="net48" />
+  <package id="Ignia.Topics.Data.Sql" version="3.8.0-alpha.257" targetFramework="net48" />
+  <package id="Ignia.Topics.ViewModels" version="3.8.0-alpha.257" targetFramework="net48" />
+  <package id="Ignia.Topics.Web" version="3.8.0-alpha.257" targetFramework="net48" />
+  <package id="Ignia.Topics.Web.Mvc" version="3.8.0-alpha.257" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.6.4" targetFramework="net47" />
@@ -27,7 +27,17 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net47" />
   <package id="NuGet.CommandLine" version="4.6.2" targetFramework="net47" developmentDependency="true" />
+  <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net48" />
+  <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net48" />
+  <package id="System.Data.SqlClient" version="4.6.0" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net47" />
+  <package id="System.IO" version="4.3.0" targetFramework="net48" />
   <package id="System.Linq" version="4.3.0" targetFramework="net47" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net48" />
   <package id="System.Threading" version="4.3.0" targetFramework="net47" />
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -3,12 +3,12 @@
   <package id="AntiXSS" version="4.3.0" targetFramework="net47" />
   <package id="Braintree" version="4.7.0" targetFramework="net47" />
   <package id="EPPlus" version="4.5.2" targetFramework="net47" />
-  <package id="Ignia.Topics" version="3.7.1" targetFramework="net47" />
-  <package id="Ignia.Topics.Data.Caching" version="3.7.1" targetFramework="net47" />
-  <package id="Ignia.Topics.Data.Sql" version="3.7.1" targetFramework="net47" />
-  <package id="Ignia.Topics.ViewModels" version="3.7.1" targetFramework="net47" />
-  <package id="Ignia.Topics.Web" version="3.7.1" targetFramework="net47" />
-  <package id="Ignia.Topics.Web.Mvc" version="3.7.1" targetFramework="net47" />
+  <package id="Ignia.Topics" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics.Data.Caching" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics.Data.Sql" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics.ViewModels" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics.Web" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics.Web.Mvc" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.6.4" targetFramework="net47" />

--- a/packages.config
+++ b/packages.config
@@ -14,7 +14,7 @@
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.10.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.10.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.SnapshotCollector" version="1.3.5" targetFramework="net48" />
-  <package id="Microsoft.ApplicationInsights.TraceListener" version="2.6.4" targetFramework="net47" />
+  <package id="Microsoft.ApplicationInsights.TraceListener" version="2.10.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.Web" version="2.10.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.10.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.10.0" targetFramework="net48" />

--- a/packages.config
+++ b/packages.config
@@ -22,7 +22,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.6" targetFramework="net47" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.6" targetFramework="net47" />
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.8" targetFramework="net47" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net47" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net47" />

--- a/packages.config
+++ b/packages.config
@@ -26,7 +26,7 @@
   <package id="Microsoft.Net.Compilers" version="3.2.1" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net48" />
-  <package id="NuGet.CommandLine" version="4.6.2" targetFramework="net47" developmentDependency="true" />
+  <package id="NuGet.CommandLine" version="5.1.0" targetFramework="net48" developmentDependency="true" />
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net48" />
   <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net48" />
   <package id="System.Data.SqlClient" version="4.6.1" targetFramework="net48" />

--- a/packages.config
+++ b/packages.config
@@ -3,12 +3,12 @@
   <package id="AntiXSS" version="4.3.0" targetFramework="net47" />
   <package id="Braintree" version="4.14.0" targetFramework="net48" />
   <package id="EPPlus" version="4.5.3.2" targetFramework="net48" />
-  <package id="Ignia.Topics" version="3.8.0-alpha.257" targetFramework="net48" />
-  <package id="Ignia.Topics.Data.Caching" version="3.8.0-alpha.257" targetFramework="net48" />
-  <package id="Ignia.Topics.Data.Sql" version="3.8.0-alpha.257" targetFramework="net48" />
-  <package id="Ignia.Topics.ViewModels" version="3.8.0-alpha.257" targetFramework="net48" />
-  <package id="Ignia.Topics.Web" version="3.8.0-alpha.257" targetFramework="net48" />
-  <package id="Ignia.Topics.Web.Mvc" version="3.8.0-alpha.257" targetFramework="net48" />
+  <package id="Ignia.Topics" version="3.8.0-alpha.267" targetFramework="net48" />
+  <package id="Ignia.Topics.Data.Caching" version="3.8.0-alpha.267" targetFramework="net48" />
+  <package id="Ignia.Topics.Data.Sql" version="3.8.0-alpha.267" targetFramework="net48" />
+  <package id="Ignia.Topics.ViewModels" version="3.8.0-alpha.267" targetFramework="net48" />
+  <package id="Ignia.Topics.Web" version="3.8.0-alpha.267" targetFramework="net48" />
+  <package id="Ignia.Topics.Web.Mvc" version="3.8.0-alpha.267" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights" version="2.10.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.10.0" targetFramework="net48" />
@@ -23,6 +23,7 @@
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
+  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net48" />
   <package id="Microsoft.Net.Compilers" version="3.2.1" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net48" />

--- a/packages.config
+++ b/packages.config
@@ -3,12 +3,12 @@
   <package id="AntiXSS" version="4.3.0" targetFramework="net47" />
   <package id="Braintree" version="4.7.0" targetFramework="net47" />
   <package id="EPPlus" version="4.5.2" targetFramework="net47" />
-  <package id="Ignia.Topics" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
-  <package id="Ignia.Topics.Data.Caching" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
-  <package id="Ignia.Topics.Data.Sql" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
-  <package id="Ignia.Topics.ViewModels" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
-  <package id="Ignia.Topics.Web" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
-  <package id="Ignia.Topics.Web.Mvc" version="Ignia.Topics.Ignia.Topics.Data.Caching.3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics.Data.Sql" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics.Data.Caching" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics.ViewModels" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics.Web" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
+  <package id="Ignia.Topics.Web.Mvc" version="3.8.0-dotnetstandard0001" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.6.4" targetFramework="net47" />

--- a/packages.config
+++ b/packages.config
@@ -18,10 +18,10 @@
   <package id="Microsoft.ApplicationInsights.Web" version="2.10.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.10.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.10.0" targetFramework="net48" />
-  <package id="Microsoft.AspNet.Mvc" version="5.2.4" targetFramework="net47" />
-  <package id="Microsoft.AspNet.Razor" version="3.2.6" targetFramework="net47" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net48" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net48" />
-  <package id="Microsoft.AspNet.WebPages" version="3.2.6" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net47" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />

--- a/packages.config
+++ b/packages.config
@@ -35,9 +35,9 @@
   <package id="System.Linq" version="4.3.0" targetFramework="net47" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />
   <package id="System.Runtime" version="4.3.1" targetFramework="net48" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net48" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net48" />
   <package id="System.Threading" version="4.3.0" targetFramework="net47" />
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="AntiXSS" version="4.3.0" targetFramework="net47" />
   <package id="Braintree" version="4.14.0" targetFramework="net48" />
-  <package id="EPPlus" version="4.5.2" targetFramework="net47" />
+  <package id="EPPlus" version="4.5.3.2" targetFramework="net48" />
   <package id="Ignia.Topics" version="3.8.0-alpha.257" targetFramework="net48" />
   <package id="Ignia.Topics.Data.Caching" version="3.8.0-alpha.257" targetFramework="net48" />
   <package id="Ignia.Topics.Data.Sql" version="3.8.0-alpha.257" targetFramework="net48" />

--- a/packages.config
+++ b/packages.config
@@ -23,7 +23,7 @@
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net48" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
-  <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net47" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="3.2.1" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net47" />
   <package id="NuGet.CommandLine" version="4.6.2" targetFramework="net47" developmentDependency="true" />

--- a/packages.config
+++ b/packages.config
@@ -25,7 +25,7 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Net.Compilers" version="3.2.1" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net48" />
   <package id="NuGet.CommandLine" version="4.6.2" targetFramework="net47" developmentDependency="true" />
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net48" />
   <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net48" />

--- a/packages.config
+++ b/packages.config
@@ -30,7 +30,7 @@
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net48" />
   <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net48" />
   <package id="System.Data.SqlClient" version="4.6.1" targetFramework="net48" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net47" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net48" />
   <package id="System.IO" version="4.3.0" targetFramework="net48" />
   <package id="System.Linq" version="4.3.0" targetFramework="net47" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />

--- a/packages.config
+++ b/packages.config
@@ -29,7 +29,7 @@
   <package id="NuGet.CommandLine" version="4.6.2" targetFramework="net47" developmentDependency="true" />
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net48" />
   <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net48" />
-  <package id="System.Data.SqlClient" version="4.6.0" targetFramework="net48" />
+  <package id="System.Data.SqlClient" version="4.6.1" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net47" />
   <package id="System.IO" version="4.3.0" targetFramework="net48" />
   <package id="System.Linq" version="4.3.0" targetFramework="net47" />

--- a/packages.config
+++ b/packages.config
@@ -9,18 +9,18 @@
   <package id="Ignia.Topics.ViewModels" version="3.8.0-alpha.257" targetFramework="net48" />
   <package id="Ignia.Topics.Web" version="3.8.0-alpha.257" targetFramework="net48" />
   <package id="Ignia.Topics.Web.Mvc" version="3.8.0-alpha.257" targetFramework="net48" />
-  <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net47" />
+  <package id="Microsoft.ApplicationInsights" version="2.10.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net47" />
-  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.6.4" targetFramework="net47" />
-  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.6.4" targetFramework="net47" />
-  <package id="Microsoft.ApplicationInsights.SnapshotCollector" version="1.3.0" targetFramework="net47" />
+  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.10.0" targetFramework="net48" />
+  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.10.0" targetFramework="net48" />
+  <package id="Microsoft.ApplicationInsights.SnapshotCollector" version="1.3.5" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.TraceListener" version="2.6.4" targetFramework="net47" />
-  <package id="Microsoft.ApplicationInsights.Web" version="2.6.4" targetFramework="net47" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.6.4" targetFramework="net47" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.6.4" targetFramework="net47" />
+  <package id="Microsoft.ApplicationInsights.Web" version="2.10.0" targetFramework="net48" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.10.0" targetFramework="net48" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.10.0" targetFramework="net48" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.4" targetFramework="net47" />
   <package id="Microsoft.AspNet.Razor" version="3.2.6" targetFramework="net47" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.3" targetFramework="net47" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.6" targetFramework="net47" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net48" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net47" developmentDependency="true" />


### PR DESCRIPTION
Upgraded **GoldSim** to **OnTopic Library 3.8.0**. This includes massive refactoring of the underlying API, which introduced breaking changes. This new version also includes support for **.NET Standard 2.1**—though **GoldSim** continues to reference the **.NET Framework 4.8** version.