### PR TITLE
Improvement/new entitlements.xlsx

### DIFF
--- a/Areas/Administration/Controllers/LicensesController.cs
+++ b/Areas/Administration/Controllers/LicensesController.cs
@@ -63,7 +63,7 @@ namespace GoldSim.Web.Areas.Administration.Controllers {
       /*------------------------------------------------------------------------------------------------------------------------
       | Return the Excel spreadsheet as a file stream
       \-----------------------------------------------------------------------------------------------------------------------*/
-      return File(memoryStream, _topicExportService.MimeType, "MultipleFreeLicenses" + _topicExportService.FileExtension);
+      return File(memoryStream, _topicExportService.MimeType, "NewEntitlements" + _topicExportService.FileExtension);
 
     }
 

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -167,47 +167,22 @@ namespace GoldSim.Web.Areas.Administration.Services {
       \-------------------------------------------------------------------------------------------------------------------------*/
       foreach (var request in licenseRequests) {
 
-        // Set variable values
-        var requestType = request.ContentType.StartsWith("Trial", StringComparison.InvariantCultureIgnoreCase) ? "Trial" : "Academic";
-        var productOptionConfiguration  = 1;
+        // Determine type.
+        var isTrial             = request.ContentType.StartsWith("Trial", StringComparison.InvariantCultureIgnoreCase);
 
-        // Determine Product Option configuration
-        if (requestedModules("Reliability", "DistributedProcessing", "RadionuclideTransport")) {
-          productOptionConfiguration    = 12;
-        }
-        else if (requestedModules("Reliability", "DistributedProcessing", "ContaminantTransport")) {
-          productOptionConfiguration    = 11;
-        }
-        else if (requestedModules("Reliability", "RadionuclideTransport")) {
-          productOptionConfiguration    = 10;
-        }
-        else if (requestedModules("Reliability", "ContaminantTransport")) {
-          productOptionConfiguration    = 9;
-        }
-        else if (requestedModules("DistributedProcessing", "RadionuclideTransport")) {
-          productOptionConfiguration    = 8;
-        }
-        else if (requestedModules("DistributedProcessing", "ContaminantTransport")) {
-          productOptionConfiguration    = 7;
-        }
-        else if (requestedModules("DistributedProcessing", "Reliability")) {
-          productOptionConfiguration    = 6;
-        }
-        else if (requestedModules("RadionuclideTransport")) {
-          productOptionConfiguration    = 5;
-        }
-        else if (requestedModules("ContaminantTransport")) {
-          productOptionConfiguration    = 4;
-        }
-        else if (requestedModules("Reliability")) {
-          productOptionConfiguration    = 3;
-        }
-        else if (requestedModules("DistributedProcessing")) {
-          productOptionConfiguration    = 2;
-        }
+        // Determine part number.
+        var partNumber          = (isTrial? "LMTD-" : "ACAD-")
+                                + (requestedModule("DistributedProcessing")? "DP-" : "00-")
+                                + (requestedModule("Reliability")? "RL-" : "00-")
+                                + (
+                                    requestedModule("ContaminantTransport")? "CT-" :
+                                    requestedModule("RadionuclideTransport")? "RT-" :
+                                    "00-"
+                                  )
+                                + (isTrial? "V." : "A.")
+                                + "15.0";
 
-        bool requestedModules(params string[] moduleList)
-          => moduleList.All(m => request.Attributes.GetBoolean($"Modules{m}", false));
+        bool requestedModule(string module) => request.Attributes.GetBoolean($"Modules{module}");
 
         //Define composite street address
         var street1             = request.Attributes.GetValue("Street1", "");
@@ -220,11 +195,11 @@ namespace GoldSim.Web.Areas.Administration.Services {
           request.Attributes.GetValue("FirstName", ""),
           request.Attributes.GetValue("LastName", ""),
           request.Attributes.GetValue("Organization", ""),
-          "Config_" + productOptionConfiguration.ToString(CultureInfo.InvariantCulture),
+          partNumber,
           "TRUE",
           "",
           "",
-          requestType,
+          isTrial? "Trial" : "Academic",
           request.Attributes.GetValue("Department", ""),
           address,
           request.Attributes.GetValue("City", ""),

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -100,8 +100,12 @@ namespace GoldSim.Web.Areas.Administration.Services {
         /*----------------------------------------------------------------------------------------------------------------------
         | Set column filters and give the Free Type column extra width to account for the filter
         \---------------------------------------------------------------------------------------------------------------------*/
-        worksheet.Column(5).Width               = 12;
         headers.AutoFilter      = true;
+
+        for (var i = 1; i <= headers.Columns; i++) {
+          var column            = worksheet.Column(i);
+          column.Width          += 2;
+        }
 
         /*----------------------------------------------------------------------------------------------------------------------
         | Apply the spreadsheet to the stream

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -106,7 +106,7 @@ namespace GoldSim.Web.Areas.Administration.Services {
         /*----------------------------------------------------------------------------------------------------------------------
         | Apply the spreadsheet to the stream
         \---------------------------------------------------------------------------------------------------------------------*/
-        memoryStream = new MemoryStream(excelPackage.GetAsByteArray());
+        memoryStream            = new MemoryStream(excelPackage.GetAsByteArray());
 
       }
 

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -132,9 +132,9 @@ namespace GoldSim.Web.Areas.Administration.Services {
       licenseRequestData.Columns.Add("First Name", typeof(string));
       licenseRequestData.Columns.Add("Last Name", typeof(string));
       licenseRequestData.Columns.Add("Company Name", typeof(string));
-      licenseRequestData.Columns.Add("Free Type", typeof(string));
       licenseRequestData.Columns.Add("Product Option", typeof(string));
       licenseRequestData.Columns.Add("Should Email?", typeof(string));
+      licenseRequestData.Columns.Add("Free Type", typeof(string));
       licenseRequestData.Columns.Add("Department", typeof(string));
       licenseRequestData.Columns.Add("Address", typeof(string));
       licenseRequestData.Columns.Add("City", typeof(string));
@@ -218,6 +218,7 @@ namespace GoldSim.Web.Areas.Administration.Services {
           requestType,
           "Config_" + productOptionConfiguration.ToString(CultureInfo.InvariantCulture),
           "TRUE",
+          requestType,
           licenseRequest.Attributes.GetValue("Department", ""),
           address,
           licenseRequest.Attributes.GetValue("City", ""),

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -82,7 +82,7 @@ namespace GoldSim.Web.Areas.Administration.Services {
         headers.Style.Font.Bold = true;
         headers.Style.Fill.PatternType = ExcelFillStyle.Solid;
         headers.Style.Fill.BackgroundColor.SetColor(headerRowBackgroundColor);
-        headers.Style.WrapText = true;
+        headers.Style.WrapText = false;
 
         worksheet.View.FreezePanes(2, 1);
 

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -219,7 +219,6 @@ namespace GoldSim.Web.Areas.Administration.Services {
           licenseRequest.Attributes.GetValue("FirstName", ""),
           licenseRequest.Attributes.GetValue("LastName", ""),
           licenseRequest.Attributes.GetValue("Organization", ""),
-          requestType,
           "Config_" + productOptionConfiguration.ToString(CultureInfo.InvariantCulture),
           "TRUE",
           "",

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -70,18 +70,19 @@ namespace GoldSim.Web.Areas.Administration.Services {
         | Get and load the data from the License Request DataTable
         \---------------------------------------------------------------------------------------------------------------------*/
         using var licenseRequestData = GetLicenseRequestData(topics);
+        using var headers       = worksheet.Cells[1, 1, 1, licenseRequestData.Columns.Count];
         worksheet.Cells.LoadFromDataTable(licenseRequestData, true);
 
         /*----------------------------------------------------------------------------------------------------------------------
         | Format the column headers
         \---------------------------------------------------------------------------------------------------------------------*/
         var headerRowBackgroundColor = ColorTranslator.FromHtml("#404040");
-        using (var cellRange = worksheet.Cells[1, 1, 1, 24]) {
-          cellRange.Style.Font.Color.SetColor(Color.White);
-          cellRange.Style.Fill.PatternType = ExcelFillStyle.Solid;
-          cellRange.Style.Fill.BackgroundColor.SetColor(headerRowBackgroundColor);
-          cellRange.Style.WrapText = true;
-        }
+
+        headers.Style.Font.Color.SetColor(Color.White);
+        headers.Style.Fill.PatternType = ExcelFillStyle.Solid;
+        headers.Style.Fill.BackgroundColor.SetColor(headerRowBackgroundColor);
+        headers.Style.WrapText = true;
+
         worksheet.View.FreezePanes(2, 1);
 
         /*----------------------------------------------------------------------------------------------------------------------

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -64,7 +64,7 @@ namespace GoldSim.Web.Areas.Administration.Services {
         /*----------------------------------------------------------------------------------------------------------------------
         | Create the worksheet
         \---------------------------------------------------------------------------------------------------------------------*/
-        var worksheet = excelPackage.Workbook.Worksheets.Add("Working");
+        var worksheet = excelPackage.Workbook.Worksheets.Add("Entitlements");
 
         /*----------------------------------------------------------------------------------------------------------------------
         | Get and load the data from the License Request DataTable

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -76,9 +76,10 @@ namespace GoldSim.Web.Areas.Administration.Services {
         /*----------------------------------------------------------------------------------------------------------------------
         | Format the column headers
         \---------------------------------------------------------------------------------------------------------------------*/
-        var headerRowBackgroundColor = ColorTranslator.FromHtml("#404040");
+        var headerRowBackgroundColor = ColorTranslator.FromHtml("#d1d1d1");
 
-        headers.Style.Font.Color.SetColor(Color.White);
+        headers.Style.Font.Color.SetColor(Color.Black);
+        headers.Style.Font.Bold = true;
         headers.Style.Fill.PatternType = ExcelFillStyle.Solid;
         headers.Style.Fill.BackgroundColor.SetColor(headerRowBackgroundColor);
         headers.Style.WrapText = true;
@@ -88,8 +89,8 @@ namespace GoldSim.Web.Areas.Administration.Services {
         /*----------------------------------------------------------------------------------------------------------------------
         | Set the font for the worksheet
         \---------------------------------------------------------------------------------------------------------------------*/
-        worksheet.Cells[worksheet.Dimension.Address].Style.Font.Name = "Tahoma";
-        worksheet.Cells[worksheet.Dimension.Address].Style.Font.Size = 10;
+        worksheet.Cells[worksheet.Dimension.Address].Style.Font.Name = "Calibri";
+        worksheet.Cells[worksheet.Dimension.Address].Style.Font.Size = 11;
 
         /*----------------------------------------------------------------------------------------------------------------------
         | Auto-fit data rows to their contents

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -69,9 +69,9 @@ namespace GoldSim.Web.Areas.Administration.Services {
         /*----------------------------------------------------------------------------------------------------------------------
         | Get and load the data from the License Request DataTable
         \---------------------------------------------------------------------------------------------------------------------*/
-        using var licenseRequestData = GetLicenseRequestData(topics);
-        using var headers       = worksheet.Cells[1, 1, 1, licenseRequestData.Columns.Count];
-        worksheet.Cells.LoadFromDataTable(licenseRequestData, true);
+        using var requests      = GetLicenseRequestData(topics);
+        using var headers       = worksheet.Cells[1, 1, 1, requests.Columns.Count];
+        worksheet.Cells.LoadFromDataTable(requests, true);
 
         /*----------------------------------------------------------------------------------------------------------------------
         | Format the column headers
@@ -125,45 +125,45 @@ namespace GoldSim.Web.Areas.Administration.Services {
       /*--------------------------------------------------------------------------------------------------------------------------
       | Establish DataTable
       \-------------------------------------------------------------------------------------------------------------------------*/
-      var licenseRequestData = new DataTable();
+      var requestData           = new DataTable();
 
       /*--------------------------------------------------------------------------------------------------------------------------
       | Set up column headers
       \-------------------------------------------------------------------------------------------------------------------------*/
-      licenseRequestData.Columns.Add("Email Address", typeof(string));
-      licenseRequestData.Columns.Add("First Name", typeof(string));
-      licenseRequestData.Columns.Add("Last Name", typeof(string));
-      licenseRequestData.Columns.Add("Company Name", typeof(string));
-      licenseRequestData.Columns.Add("Product", typeof(string));
-      licenseRequestData.Columns.Add("Should Email?", typeof(string));
-      licenseRequestData.Columns.Add("Account ID", typeof(string));
-      licenseRequestData.Columns.Add("Expiration Date", typeof(string));
-      licenseRequestData.Columns.Add("Free Type", typeof(string));
-      licenseRequestData.Columns.Add("Department", typeof(string));
-      licenseRequestData.Columns.Add("Address", typeof(string));
-      licenseRequestData.Columns.Add("City", typeof(string));
-      licenseRequestData.Columns.Add("State", typeof(string));
-      licenseRequestData.Columns.Add("Postal", typeof(string));
-      licenseRequestData.Columns.Add("Country", typeof(string));
-      licenseRequestData.Columns.Add("Phone", typeof(string));
-      licenseRequestData.Columns.Add("Focus Area", typeof(string));
-      licenseRequestData.Columns.Add("Referral Source", typeof(string));
-      licenseRequestData.Columns.Add("Referral Details", typeof(string));
-      licenseRequestData.Columns.Add("Problem Description", typeof(string));
-      licenseRequestData.Columns.Add("Existing Tools Description", typeof(string));
-      licenseRequestData.Columns.Add("Sponsor First Name", typeof(string));
-      licenseRequestData.Columns.Add("Sponsor Last Name", typeof(string));
-      licenseRequestData.Columns.Add("Sponsor Department", typeof(string));
-      licenseRequestData.Columns.Add("Sponsor Email", typeof(string));
-      licenseRequestData.Columns.Add("Sponsor Phone", typeof(string));
+      requestData.Columns.Add("Email Address",                  typeof(string));
+      requestData.Columns.Add("First Name",                     typeof(string));
+      requestData.Columns.Add("Last Name",                      typeof(string));
+      requestData.Columns.Add("Company Name",                   typeof(string));
+      requestData.Columns.Add("Product",                        typeof(string));
+      requestData.Columns.Add("Should Email?",                  typeof(string));
+      requestData.Columns.Add("Account ID",                     typeof(string));
+      requestData.Columns.Add("Expiration Date",                typeof(string));
+      requestData.Columns.Add("Free Type",                      typeof(string));
+      requestData.Columns.Add("Department",                     typeof(string));
+      requestData.Columns.Add("Address",                        typeof(string));
+      requestData.Columns.Add("City",                           typeof(string));
+      requestData.Columns.Add("State",                          typeof(string));
+      requestData.Columns.Add("Postal",                         typeof(string));
+      requestData.Columns.Add("Country",                        typeof(string));
+      requestData.Columns.Add("Phone",                          typeof(string));
+      requestData.Columns.Add("Focus Area",                     typeof(string));
+      requestData.Columns.Add("Referral Source",                typeof(string));
+      requestData.Columns.Add("Referral Details",               typeof(string));
+      requestData.Columns.Add("Problem Description",            typeof(string));
+      requestData.Columns.Add("Existing Tools Description",     typeof(string));
+      requestData.Columns.Add("Sponsor First Name",             typeof(string));
+      requestData.Columns.Add("Sponsor Last Name",              typeof(string));
+      requestData.Columns.Add("Sponsor Department",             typeof(string));
+      requestData.Columns.Add("Sponsor Email",                  typeof(string));
+      requestData.Columns.Add("Sponsor Phone",                  typeof(string));
 
       /*--------------------------------------------------------------------------------------------------------------------------
       | Set row data
       \-------------------------------------------------------------------------------------------------------------------------*/
-      foreach (var licenseRequest in licenseRequests) {
+      foreach (var request in licenseRequests) {
 
         // Set variable values
-        var requestType = licenseRequest.ContentType.StartsWith("Trial", StringComparison.InvariantCultureIgnoreCase) ? "Trial" : "Academic";
+        var requestType = request.ContentType.StartsWith("Trial", StringComparison.InvariantCultureIgnoreCase) ? "Trial" : "Academic";
         var productOptionConfiguration  = 1;
 
         // Determine Product Option configuration
@@ -202,11 +202,11 @@ namespace GoldSim.Web.Areas.Administration.Services {
         }
 
         bool requestedModules(params string[] moduleList)
-          => moduleList.All(m => licenseRequest.Attributes.GetBoolean($"Modules{m}", false));
+          => moduleList.All(m => request.Attributes.GetBoolean($"Modules{m}", false));
 
         //Define composite street address
-        var street1 = licenseRequest.Attributes.GetValue("Street1", "");
-        var street2 = licenseRequest.Attributes.GetValue("Street2", "");
+        var street1 = request.Attributes.GetValue("Street1", "");
+        var street2 = request.Attributes.GetValue("Street2", "");
         var address = street1;
 
         if (!String.IsNullOrWhiteSpace(street2)) {
@@ -214,33 +214,33 @@ namespace GoldSim.Web.Areas.Administration.Services {
         }
 
         // Add data row for each request
-        licenseRequestData.Rows.Add(
-          licenseRequest.Attributes.GetValue("Email", ""),
-          licenseRequest.Attributes.GetValue("FirstName", ""),
-          licenseRequest.Attributes.GetValue("LastName", ""),
-          licenseRequest.Attributes.GetValue("Organization", ""),
+        requestData.Rows.Add(
+          request.Attributes.GetValue("Email", ""),
+          request.Attributes.GetValue("FirstName", ""),
+          request.Attributes.GetValue("LastName", ""),
+          request.Attributes.GetValue("Organization", ""),
           "Config_" + productOptionConfiguration.ToString(CultureInfo.InvariantCulture),
           "TRUE",
           "",
           "",
           requestType,
-          licenseRequest.Attributes.GetValue("Department", ""),
+          request.Attributes.GetValue("Department", ""),
           address,
-          licenseRequest.Attributes.GetValue("City", ""),
-          licenseRequest.Attributes.GetValue("Province", ""),
-          licenseRequest.Attributes.GetValue("PostalCode", ""),
-          licenseRequest.Attributes.GetValue("Country", ""),
-          licenseRequest.Attributes.GetValue("PhoneNumber", ""),
-          licenseRequest.Attributes.GetValue("AreaOfFocus", ""),
-          licenseRequest.Attributes.GetValue("ReferralSource", ""),
-          licenseRequest.Attributes.GetValue("ReferralDetails", ""),
-          licenseRequest.Attributes.GetValue("ProblemStatement", ""),
-          licenseRequest.Attributes.GetValue("OtherTools", ""),
-          licenseRequest.Attributes.GetValue("SponsorFirstName", ""),
-          licenseRequest.Attributes.GetValue("SponsorLastName", ""),
-          licenseRequest.Attributes.GetValue("SponsorOrganization", ""),
-          licenseRequest.Attributes.GetValue("SponsorEmail", ""),
-          licenseRequest.Attributes.GetValue("SponsorPhoneNumber", "")
+          request.Attributes.GetValue("City", ""),
+          request.Attributes.GetValue("Province", ""),
+          request.Attributes.GetValue("PostalCode", ""),
+          request.Attributes.GetValue("Country", ""),
+          request.Attributes.GetValue("PhoneNumber", ""),
+          request.Attributes.GetValue("AreaOfFocus", ""),
+          request.Attributes.GetValue("ReferralSource", ""),
+          request.Attributes.GetValue("ReferralDetails", ""),
+          request.Attributes.GetValue("ProblemStatement", ""),
+          request.Attributes.GetValue("OtherTools", ""),
+          request.Attributes.GetValue("SponsorFirstName", ""),
+          request.Attributes.GetValue("SponsorLastName", ""),
+          request.Attributes.GetValue("SponsorOrganization", ""),
+          request.Attributes.GetValue("SponsorEmail", ""),
+          request.Attributes.GetValue("SponsorPhoneNumber", "")
         );
 
       }
@@ -248,7 +248,7 @@ namespace GoldSim.Web.Areas.Administration.Services {
       /*--------------------------------------------------------------------------------------------------------------------------
       | Return DataTable
       \-------------------------------------------------------------------------------------------------------------------------*/
-      return licenseRequestData;
+      return requestData;
 
     }
 

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -132,8 +132,10 @@ namespace GoldSim.Web.Areas.Administration.Services {
       licenseRequestData.Columns.Add("First Name", typeof(string));
       licenseRequestData.Columns.Add("Last Name", typeof(string));
       licenseRequestData.Columns.Add("Company Name", typeof(string));
-      licenseRequestData.Columns.Add("Product Option", typeof(string));
+      licenseRequestData.Columns.Add("Product", typeof(string));
       licenseRequestData.Columns.Add("Should Email?", typeof(string));
+      licenseRequestData.Columns.Add("Account ID", typeof(string));
+      licenseRequestData.Columns.Add("Expiration Date", typeof(string));
       licenseRequestData.Columns.Add("Free Type", typeof(string));
       licenseRequestData.Columns.Add("Department", typeof(string));
       licenseRequestData.Columns.Add("Address", typeof(string));
@@ -218,6 +220,8 @@ namespace GoldSim.Web.Areas.Administration.Services {
           requestType,
           "Config_" + productOptionConfiguration.ToString(CultureInfo.InvariantCulture),
           "TRUE",
+          "",
+          "",
           requestType,
           licenseRequest.Attributes.GetValue("Department", ""),
           address,

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -99,8 +99,8 @@ namespace GoldSim.Web.Areas.Administration.Services {
         /*----------------------------------------------------------------------------------------------------------------------
         | Set column filters and give the Free Type column extra width to account for the filter
         \---------------------------------------------------------------------------------------------------------------------*/
-        worksheet.Cells["E1:F1"].AutoFilter     = true;
         worksheet.Column(5).Width               = 12;
+        headers.AutoFilter      = true;
 
         /*----------------------------------------------------------------------------------------------------------------------
         | Apply the spreadsheet to the stream
@@ -110,6 +110,7 @@ namespace GoldSim.Web.Areas.Administration.Services {
       }
 
       return memoryStream;
+
     }
 
     /*============================================================================================================================

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -210,13 +210,9 @@ namespace GoldSim.Web.Areas.Administration.Services {
           => moduleList.All(m => request.Attributes.GetBoolean($"Modules{m}", false));
 
         //Define composite street address
-        var street1 = request.Attributes.GetValue("Street1", "");
-        var street2 = request.Attributes.GetValue("Street2", "");
-        var address = street1;
-
-        if (!String.IsNullOrWhiteSpace(street2)) {
-          address += $", {street2}";
-        }
+        var street1             = request.Attributes.GetValue("Street1", "");
+        var street2             = request.Attributes.GetValue("Street2", "");
+        var address             = street1 + (!String.IsNullOrWhiteSpace(street2)? $", {street2}" : "");
 
         // Add data row for each request
         requestData.Rows.Add(

--- a/Areas/Administration/Services/LicenseExportService.cs
+++ b/Areas/Administration/Services/LicenseExportService.cs
@@ -84,7 +84,7 @@ namespace GoldSim.Web.Areas.Administration.Services {
         headers.Style.Fill.BackgroundColor.SetColor(headerRowBackgroundColor);
         headers.Style.WrapText = false;
 
-        worksheet.View.FreezePanes(2, 1);
+        worksheet.View.FreezePanes(2, 2);
 
         /*----------------------------------------------------------------------------------------------------------------------
         | Set the font for the worksheet


### PR DESCRIPTION
Update the spreadsheet exported by the License Requests Administration tool to align with the new format expected by `FLiP Create Bulk` command (GoldSim/FliP#31). 

As part of this, I renamed the workbook to `NewEntitlements.xlsx` (810b5263), the worksheet to `Entitlements` (01f419b7); I moved "Free Type" after "Should Email?" to ensure the expected order of the columns used by FLiP (1960e1b5, e1b681f9); and I also added the two optional columns expected by FLiP (i.e., "Part Number" and "Account ID"; 9e2187a9), even though those will be left blank and assigned defaults by FLiP. I also aligned the header styles with FLiP (de0e08de, 5234e771), froze the first column (579af172), and disabled value wrapping (f56ef127). Finally, I updated the product column to use the part number, not the `Config_#` value, which required calculating the part number based on the user request (8e51aeba).

I also cleaned up some of the Excel code by e.g., setting the headers cell range to a variable (e82271d5) and then using this to extend the auto-filter to all of the header columns (8d8c80f1). I also preferred shorter variable names (f7eae195), aligned variable assignments (35d890c8), and simplified how address is defined (b9b08aa7).