### PR TITLE
Courses Search

### DIFF
--- a/Areas/Courses/Views/Layout/_Layout.cshtml
+++ b/Areas/Courses/Views/Layout/_Layout.cshtml
@@ -18,6 +18,15 @@
     };
   </script>
   <script type="text/javascript" id="MathJax-script" async src="//cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+  @RenderSection("Head", required: false)
+}
+
+@section Scripts {
+  @RenderSection("Scripts", required: false)
+}
+
+@section InlineScript {
+  @RenderSection("InlineScript", required: false)
 }
 
 @section HeaderSection {

--- a/Shared/Scripts/Views/Search.js
+++ b/Shared/Scripts/Views/Search.js
@@ -147,10 +147,10 @@
     // Render search results
     for (var i                  = 0; i < searchResults.length; i++) {
 
-      var title                 = searchResults[i].title;
+      var title                 = searchResults[i].htmlTitle;
       var url                   = searchResults[i].link;
       var displayUrl            = searchResults[i].displayLink;
-      var snippet               = searchResults[i].snippet;
+      var snippet               = searchResults[i].htmlSnippet;
 
       var searchResult          =
         '<div class="result">' +

--- a/Shared/Scripts/Views/Search.js
+++ b/Shared/Scripts/Views/Search.js
@@ -122,7 +122,7 @@
     * search results markup.
     */
   Plugin.prototype.getSearchResults = function(offset) {
-    offset                      = offset? offset : 0;
+    offset                      = offset? offset : 1;
     $.ajax({
       url                       : this._baseApiUrl + '&start=' + offset,
       success                   : this.bindSearchResults.bind(this)
@@ -223,7 +223,7 @@
     var pageNumber              = Number(source.data("page") || 1);
     window.location.hash        = "Page" + pageNumber;
 
-    this.getSearchResults((pageNumber-1)*this.options.pageSize);
+    this.getSearchResults((pageNumber-1)*this.options.pageSize+1);
 
   };
 

--- a/Shared/Scripts/Views/Search.js
+++ b/Shared/Scripts/Views/Search.js
@@ -18,6 +18,7 @@
   var defaults                  = {
     apiKey                      : null,
     customConfig                : null,
+    scope                       : null,
     queryStringParameter        : 'SearchText',
     previousButton              : 'PreviousPage',
     nextButton                  : 'NextPage',
@@ -63,6 +64,10 @@
         '?key='                 + this.options.apiKey +
         '&cx='                  + this.options.customConfig +
         '&q='                   + encodeURIComponent(this._searchQuery);
+
+    if (this.options.scope) {
+      this._baseApiUrl          += " site:" + this.options.scope;
+    }
 
     /**
      * Locate user interface elements

--- a/Views/Search/Search.cshtml
+++ b/Views/Search/Search.cshtml
@@ -1,5 +1,7 @@
-﻿@using Microsoft.Extensions.Configuration
+﻿@using System.Text.Encodings.Web
+@using Microsoft.Extensions.Configuration
 @inject IConfiguration Configuration
+@model PageTopicViewModel
 
 @section Head {
   <link rel="stylesheet" href="~/Shared/Styles/Views/Search.css" type="text/css" media="all" asp-append-version="true" />
@@ -31,7 +33,10 @@
 
   $("#SearchResults").googleSearch({
     apiKey                      : '@Configuration["GoogleSearch:ApiKey"]',
-    customConfig                : '@Configuration["GoogleSearch:CustomConfig"]'
+    customConfig                : '@Configuration["GoogleSearch:CustomConfig"]',
+    @if (Model.Parent?.ContentType.Equals("Course")?? false) {
+      @:scope                   : '@UrlEncoder.Default.Encode($"https://www.goldsim.com{Model.Parent.WebPath}")'
+    }
   })
 
 }

--- a/Views/Search/Search.cshtml
+++ b/Views/Search/Search.cshtml
@@ -3,6 +3,12 @@
 @inject IConfiguration Configuration
 @model PageTopicViewModel
 
+@{
+  if (Model.Parent?.ContentType.Equals("Course")?? false) {
+    Layout = "~/Areas/Courses/Views/Layout/_Layout.cshtml";
+  }
+}
+
 @section Head {
   <link rel="stylesheet" href="~/Shared/Styles/Views/Search.css" type="text/css" media="all" asp-append-version="true" />
 }

--- a/Views/Shared/_SearchBar.cshtml
+++ b/Views/Shared/_SearchBar.cshtml
@@ -1,6 +1,9 @@
 ﻿@model PageTopicViewModel
 @{
-  var action                    = Model.WebPath.StartsWith("/Courses/", StringComparison.OrdinalIgnoreCase)? Model.WebPath[..Model.WebPath.IndexOf('/', "/Courses/".Length)] + "/Search" : "/Web/Search/";
+  var action                    = "/Web/Search/";
+  if (Model.WebPath.StartsWith("/Courses/", StringComparison.OrdinalIgnoreCase) && !Model.WebPath.Equals("/Courses/", StringComparison.OrdinalIgnoreCase)) {
+    action                      = Model.WebPath[..Model.WebPath.IndexOf('/', "/Courses/".Length)] + "/Search";
+  }
 }
 
 <div class="search form closed">

--- a/Views/Shared/_SearchBar.cshtml
+++ b/Views/Shared/_SearchBar.cshtml
@@ -1,5 +1,10 @@
-﻿<div class="search form closed">
-  <form id="SearchBarSearchForm" action="/Web/Search/">
+﻿@model PageTopicViewModel
+@{
+  var action                    = Model.WebPath.StartsWith("/Courses/", StringComparison.OrdinalIgnoreCase)? Model.WebPath[..Model.WebPath.IndexOf('/', "/Courses/".Length)] + "/Search" : "/Web/Search/";
+}
+
+<div class="search form closed">
+  <form id="SearchBarSearchForm" action="@action">
     <!-- Search Input -->
     <div class="input">
       <input type="search" id="SearchBarSearchQuery" name="SearchText" />


### PR DESCRIPTION
Updated the global search box to only search the current course if a customer is taking a course. This required adding a `scope` option to the `googleSearch` jQuery Plugin (c8f06849) and relaying it from the search form (a9cfc95a). As part of this, I also added a search page to each of the courses, set it as the target for those searches (13d254a2, f44fb8d9), and updated it to use the courses template (cb3c8374, 13515f0e).

While I was at it, I also updated the search results to highlight search terms (7d5e1ef7), and fixed a bug which caused a duplicate result on each page (72fa16cb). 